### PR TITLE
Pagination & Channel search

### DIFF
--- a/apps/channel/tests.py
+++ b/apps/channel/tests.py
@@ -300,7 +300,9 @@ class ChannelSearchTest(TestCase):
     def test_all_search(self):
         type = "all"
         keyword = "와플"
-        all_search = self.client.get(f"/api/v1/search/?type={type}&q={keyword}")
+        all_search = self.client.get(
+            f"/api/v1/channels/search/?type={type}&q={keyword}"
+        )
         data = all_search.json()["results"]
 
         self.assertEqual(len(data), 2)
@@ -315,7 +317,9 @@ class ChannelSearchTest(TestCase):
     def test_description_search(self):
         type = "description"
         keyword = "맛있는"
-        description_search = self.client.get(f"/api/v1/search/?type={type}&q={keyword}")
+        description_search = self.client.get(
+            f"/api/v1/channels/search/?type={type}&q={keyword}"
+        )
         data = description_search.json()["results"]
 
         self.assertEqual(len(data), 1)
@@ -334,7 +338,9 @@ class ChannelSearchTest(TestCase):
     def test_name_search(self):
         type = "name"
         keyword = "wafflestudio"
-        name_search = self.client.get(f"/api/v1/search/?type={type}&q={keyword}")
+        name_search = self.client.get(
+            f"/api/v1/channels/search/?type={type}&q={keyword}"
+        )
         data = name_search.json()["results"]
 
         self.assertEqual(len(data), 1)
@@ -354,7 +360,7 @@ class ChannelSearchTest(TestCase):
         type = "all"
         keyword = "와"
         less_than_two_search = self.client.get(
-            f"/api/v1/search/?type={type}&q={keyword}"
+            f"/api/v1/channels/search/?type={type}&q={keyword}"
         )
 
         self.assertEqual(less_than_two_search.status_code, 400)
@@ -362,6 +368,8 @@ class ChannelSearchTest(TestCase):
     def test_invalid_keyword(self):
         type = "all"
         keyword = "검색되지않는단어"
-        not_search = self.client.get(f"/api/v1/search/?type={type}&q={keyword}")
+        not_search = self.client.get(
+            f"/api/v1/channels/search/?type={type}&q={keyword}"
+        )
 
         self.assertEqual(not_search.status_code, 400)

--- a/apps/channel/tests.py
+++ b/apps/channel/tests.py
@@ -209,7 +209,7 @@ class ChannelPermissionTest(TestCase):
         not_subscribe = self.client.post(
             f"/api/v1/channels/{self.private_channel.id}/awaiters/allow/{self.c.id}/"
         )
-        self.assertEqual(reallow.status_code, 400)
+        self.assertEqual(not_subscribe.status_code, 400)
 
     def test_private_subscribe_and_disallow(self):
         self.client.force_authenticate(user=self.b)
@@ -221,22 +221,31 @@ class ChannelPermissionTest(TestCase):
         self.assertEqual(self.private_channel.awaiters.count(), 1)
 
         self.client.force_authenticate(user=self.user)
-        allow = self.client.delete(
+        disallow = self.client.delete(
             f"/api/v1/channels/{self.private_channel.id}/awaiters/allow/{self.b.id}/"
         )
-        self.assertEqual(allow.status_code, 200)
+        self.assertEqual(disallow.status_code, 200)
         self.assertEqual(self.private_channel.awaiters.count(), 0)
         self.assertEqual(self.private_channel.subscribers.count(), 0)
 
-        reallow = self.client.post(
-            f"/api/v1/channels/{self.private_channel.id}/awaiters/allow/{self.b.id}/"
-        )
-        self.assertEqual(reallow.status_code, 400)
-
-        not_subscribe = self.client.post(
+        not_subscribe = self.client.delete(
             f"/api/v1/channels/{self.private_channel.id}/awaiters/allow/{self.c.id}/"
         )
-        self.assertEqual(reallow.status_code, 400)
+        self.assertEqual(not_subscribe.status_code, 400)
+
+        self.client.force_authenticate(user=self.b)
+        subscribe = self.client.post(
+            f"/api/v1/channels/{self.private_channel.id}/subscribe/"
+        )
+        self.client.force_authenticate(user=self.user)
+        allow = self.client.post(
+            f"/api/v1/channels/{self.private_channel.id}/awaiters/allow/{self.b.id}/"
+        )
+
+        redisallow = self.client.delete(
+            f"/api/v1/channels/{self.private_channel.id}/awaiters/allow/{self.b.id}/"
+        )
+        self.assertEqual(redisallow.status_code, 400)
 
     def test_delete_last_manager_fail(self):
         self.client.force_authenticate(user=self.user)

--- a/apps/channel/urls.py
+++ b/apps/channel/urls.py
@@ -1,12 +1,11 @@
 from django.urls import include, path
 from rest_framework.routers import SimpleRouter
-from apps.channel.views import ChannelViewSet, ChannelSearchViewSet
+from apps.channel.views import ChannelViewSet
 
 app_name = "channel"
 
 router = SimpleRouter()
 router.register("channels", ChannelViewSet, basename="channel")
-router.register("search", ChannelSearchViewSet, basename="search")
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/apps/channel/views.py
+++ b/apps/channel/views.py
@@ -63,12 +63,6 @@ class ChannelViewSet(viewsets.ModelViewSet):
 
         return Response(serializer.data)
 
-    def list(self, request):
-        qs = self.get_queryset()
-        page = self.paginate_queryset(qs)
-        data = self.get_serializer(page, many=True).data
-        return self.get_paginated_response(data)
-
     @action(detail=True, methods=["post"])
     def subscribe(self, request, pk):
         """

--- a/apps/channel/views.py
+++ b/apps/channel/views.py
@@ -63,6 +63,12 @@ class ChannelViewSet(viewsets.ModelViewSet):
 
         return Response(serializer.data)
 
+    def list(self, request):
+        qs = self.get_queryset()
+        page = self.paginate_queryset(qs)
+        data = self.get_serializer(page, many=True).data
+        return self.get_paginated_response(data)
+
     @action(detail=True, methods=["post"])
     def subscribe(self, request, pk):
         """
@@ -181,54 +187,39 @@ class ChannelViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(channels, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-
-class ChannelSearchViewSet(viewsets.GenericViewSet):
-    serializer_class = ChannelSerializer
-    permission_classes = [ManagerCanModify]
-
-    def get_queryset(self):
-        search_keyword = self.request.GET.get("q", "")
-        search_type = self.request.GET.get("type", "")
-        channel_list = Channel.objects.all()
-        if search_keyword:
-            if len(search_keyword) >= 2:
-                if search_type == "all":
-                    search_channel_list = channel_list.filter(
-                        Q(name__icontains=search_keyword)
-                        | Q(description__icontains=search_keyword)
-                    )
-                elif search_type == "name":
-                    search_channel_list = channel_list.filter(
-                        Q(name__icontains=search_keyword)
-                    )
-                elif search_type == "description":
-                    search_channel_list = channel_list.filter(
-                        Q(description__icontains=search_keyword)
-                    )
-                return search_channel_list
-        return channel_list
-
-    def list(self, request):
+    @action(detail=False, methods=["get"])
+    def search(self, request):
         """
         # 채널 검색 API
         * params의 'type'으로 검색 타입 'all', 'name', 'description'을 받음
         * pararms의 'q'로 검색어를 받음
         """
-        qs = self.get_queryset()
+        qs = Channel.objects.all()
         param = request.query_params
         search_keyword = self.request.GET.get("q", "")
         search_type = self.request.GET.get("type", "")
-        page = self.paginate_queryset(qs)
 
         if len(param["q"]) < 2:
             return Response(
                 {"error": "검색어를 두 글자 이상 입력해주세요"}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        elif not qs.exists():
-            return Response(
-                {"error": "검색 결과가 없습니다."}, status=status.HTTP_400_BAD_REQUEST
-            )
+        if search_keyword:
+            if search_type == "all":
+                qs = qs.filter(
+                    Q(name__icontains=search_keyword)
+                    | Q(description__icontains=search_keyword)
+                )
+            elif search_type == "name":
+                qs = qs.filter(Q(name__icontains=search_keyword))
+            elif search_type == "description":
+                qs = qs.filter(Q(description__icontains=search_keyword))
+
+            if not qs.exists():
+                return Response(
+                    {"error": "검색 결과가 없습니다."}, status=status.HTTP_400_BAD_REQUEST
+                )
+        page = self.paginate_queryset(qs)
 
         data = self.get_serializer(page, many=True).data
         return self.get_paginated_response(data)

--- a/apps/user/tests.py
+++ b/apps/user/tests.py
@@ -14,6 +14,15 @@ class UserCreateDeleteTest(TestCase):
             first_name="first",
             last_name="last",
         )
+
+        self.b = User.objects.create_user(
+            username="testuser2",
+            email="email2@email.com",
+            password="password",
+            first_name="first",
+            last_name="last",
+        )
+
         self.data = {
             "username": "snuday",
             "password": "password",
@@ -83,7 +92,7 @@ class UserCreateDeleteTest(TestCase):
         self.assertEqual(get.status_code, 200)
 
     def test_update_user(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.b)
 
         username = "apple"
         email = "samsung@snu.ac.kr"
@@ -118,6 +127,9 @@ class UserCreateDeleteTest(TestCase):
         self.assertEqual(subscribing.status_code, 200)
         self.assertEqual(len(data), 1)
 
+        others = self.client.get(f"/api/v1/users/{self.b.id}/subscribing_channels/")
+        self.assertEqual(others.status_code, 403)
+
     def test_get_users_managing_channels(self):
         self.client.force_authenticate(user=self.user)
 
@@ -129,3 +141,6 @@ class UserCreateDeleteTest(TestCase):
         self.assertEqual(managing.status_code, 200)
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["name"], "wafflestudio")
+
+        others = self.client.get(f"/api/v1/users/{self.b.id}/managing_channels/")
+        self.assertEqual(others.status_code, 403)

--- a/apps/user/tests.py
+++ b/apps/user/tests.py
@@ -21,6 +21,14 @@ class UserCreateDeleteTest(TestCase):
             "last_name": "Kim",
             "email": "snuday@snu.ac.kr",
         }
+
+        self.channel_data = {
+            "name": "wafflestudio",
+            "description": "맛있는 서비스가 탄생하는 곳, 서울대학교 컴퓨터공학부 웹/앱 개발 동아리 와플스튜디오입니다!",
+            "is_private": False,
+            "managers_id": [self.user.id],
+        }
+
         self.client = APIClient()
 
     def test_create_user(self):
@@ -95,7 +103,7 @@ class UserCreateDeleteTest(TestCase):
         self.assertEqual(user.username, username)
         self.assertEqual(user.email, email)
 
-    def test_get_users_channel(self):
+    def test_get_users_subscribing_channels(self):
         self.client.force_authenticate(user=self.user)
 
         channel = Channel.objects.create(
@@ -104,7 +112,20 @@ class UserCreateDeleteTest(TestCase):
         )
         UserChannel.objects.create(user=self.user, channel=channel)
 
-        get = self.client.get("/api/v1/users/me/channels/")
+        subscribing = self.client.get("/api/v1/users/me/subscribing_channels/")
+        data = subscribing.json()["results"]
 
-        self.assertEqual(get.status_code, 200)
-        self.assertEqual(len(get.data), 1)
+        self.assertEqual(subscribing.status_code, 200)
+        self.assertEqual(len(data), 1)
+
+    def test_get_users_managing_channels(self):
+        self.client.force_authenticate(user=self.user)
+
+        create = self.client.post("/api/v1/channels/", self.channel_data, format="json")
+
+        managing = self.client.get("/api/v1/users/me/managing_channels/")
+        data = managing.json()["results"]
+
+        self.assertEqual(managing.status_code, 200)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["name"], "wafflestudio")

--- a/apps/user/views.py
+++ b/apps/user/views.py
@@ -15,7 +15,8 @@ class UserViewSet(
     queryset = User.objects.all()
     serializer_classes = {
         "default": UserSerializer,
-        "channels": ChannelSerializer,
+        "subscribing_channels": ChannelSerializer,
+        "managing_channels": ChannelSerializer,
     }
 
     def get_permissions(self):
@@ -51,11 +52,29 @@ class UserViewSet(
         return Response(serializer.data)
 
     @action(detail=True, methods=["GET"])
-    def channels(self, request, pk=None):
+    def subscribing_channels(self, request, pk=None):
+        """
+        # 구독 중인 채널
+        """
         if pk != "me":
             return Response(
                 "다른 이가 구독중인 채널을 볼 수 없습니다.", status=status.HTTP_403_FORBIDDEN
             )
         qs = request.user.subscribing_channels.all()
-        data = self.get_serializer(qs, many=True).data
-        return Response(data)
+        page = self.paginate_queryset(qs)
+        data = self.get_serializer(page, many=True).data
+        return self.get_paginated_response(data)
+
+    @action(detail=True, methods=["GET"])
+    def managing_channels(self, request, pk=None):
+        """
+        # 관리 중인 채널
+        """
+        if pk != "me":
+            return Response(
+                "다른 이가 관리중인 채널을 볼 수 없습니다.", status=status.HTTP_403_FORBIDDEN
+            )
+        qs = request.user.managing_channels.all()
+        page = self.paginate_queryset(qs)
+        data = self.get_serializer(page, many=True).data
+        return self.get_paginated_response(data)


### PR DESCRIPTION
1. `/users/{id}/channels/`에 관하여

      - `/users/{id}/channels/`를 유저가 구독 중인 채널들을 위한 `/users/{id}/subscribing_channels/` 와 유저가 관리 중인 채널들을 위한 `/users/{id}/managing_channels/` 로 나누고 각각 pagination을 적용했습니다.
   
2. `GET /search/` 대신 `GET /channels/search/` 로 수정

