### PR TITLE
channel name uniqueness & change password user info verification

### DIFF
--- a/apps/channel/tests.py
+++ b/apps/channel/tests.py
@@ -107,7 +107,7 @@ class ChannelPermissionTest(TestCase):
         self.client.force_authenticate(user=self.user)
 
         content = "내가 할 수 있는 건"
-        new_managers = [self.b.id]
+        new_managers = [self.b.username]
 
         update = self.client.patch(
             f"/api/v1/channels/{self.public_channel.id}/",
@@ -260,7 +260,7 @@ class ChannelPermissionTest(TestCase):
         self.client.force_authenticate(user=self.user)
         add_manager = self.client.patch(
             f"/api/v1/channels/{self.public_channel.id}/",
-            {"managers_id": [self.user.id, self.b.id]},
+            {"managers_id": [self.user.username, self.b.username]},
             format="json",
         )
         self.assertEqual(add_manager.status_code, 200)
@@ -269,7 +269,7 @@ class ChannelPermissionTest(TestCase):
 
         delete_manager = self.client.patch(
             f"/api/v1/channels/{self.public_channel.id}/",
-            {"managers_id": [self.user.id]},
+            {"managers_id": [self.user.username]},
             format="json",
         )
         self.assertEqual(self.public_channel.subscribers.count(), 2)

--- a/apps/channel/views.py
+++ b/apps/channel/views.py
@@ -26,12 +26,13 @@ class ChannelViewSet(viewsets.ModelViewSet):
         user = request.user
         data = request.data.copy()
 
-        q_channel = Channel.objects.filter(name=data["name"]).first()
+        if "name" in data:
+            q_channel = Channel.objects.filter(name=data["name"]).first()
 
-        if q_channel is not None:
-            return Response(
-                {"error": "동일한 이름의 채널이 존재합니다."}, status=status.HTTP_400_BAD_REQUEST
-            )
+            if q_channel is not None:
+                return Response(
+                    {"error": "동일한 이름의 채널이 존재합니다."}, status=status.HTTP_400_BAD_REQUEST
+                )
 
         data["managers_id"].append(user.username)
 
@@ -59,12 +60,13 @@ class ChannelViewSet(viewsets.ModelViewSet):
         channel = self.get_object()
         data = request.data.copy()
 
-        q_channel = Channel.objects.filter(name=data["name"]).first()
-        print(q_channel)
-        if q_channel is not None:
-            return Response(
-                {"error": "동일한 이름의 채널이 존재합니다."}, status=status.HTTP_400_BAD_REQUEST
-            )
+        if "name" in data:
+            q_channel = Channel.objects.filter(name=data["name"]).first()
+
+            if q_channel is not None:
+                return Response(
+                    {"error": "동일한 이름의 채널이 존재합니다."}, status=status.HTTP_400_BAD_REQUEST
+                )
 
         serializer = self.get_serializer(channel, data=data, partial=True)
         validated_data = serializer.is_valid(raise_exception=True)

--- a/apps/user/test_email.py
+++ b/apps/user/test_email.py
@@ -63,7 +63,13 @@ class EmailTest(TestCase):
     def test_password_mail(self):
         self.assertEqual(EmailInfo.objects.count(), 1)
         send = self.client.post(
-            "/api/v1/users/find/password/", {"email_prefix": "heka1024"}
+            "/api/v1/users/find/password/",
+            {
+                "username": self.user.username,
+                "first_name": self.user.first_name,
+                "last_name": self.user.last_name,
+                "email_prefix": "heka1024",
+            },
         )
 
         self.assertEqual(send.status_code, 200)


### PR DESCRIPTION
- channel 생성 및 수정시 기존의 채널과 이름 중복 방지
- password 재발급시 user의 성, 이름, username으로 verification 진행