### PR TITLE
CHORE: Support utf8mb4 in django settings

### DIFF
--- a/settings/base.py
+++ b/settings/base.py
@@ -93,9 +93,7 @@ DATABASES = {
         "NAME": os.environ.get("DB_NAME"),
         "USER": os.environ.get("DB_USERNAME"),
         "PASSWORD": os.environ.get("DB_PASSWORD"),
-        "OPTIONS": {
-            'charset' : 'utf8mb4'
-        }
+        "OPTIONS": {"charset": "utf8mb4"},
     },
 }
 

--- a/settings/base.py
+++ b/settings/base.py
@@ -93,6 +93,9 @@ DATABASES = {
         "NAME": os.environ.get("DB_NAME"),
         "USER": os.environ.get("DB_USERNAME"),
         "PASSWORD": os.environ.get("DB_PASSWORD"),
+        "OPTIONS": {
+            'charset' : 'utf8mb4'
+        }
     },
 }
 


### PR DESCRIPTION
django app에서 이모지가 깨지는 버그를 해결하기 위해 `utf8mb4`를 지원하도록 설정하였습니다.