### PR TITLE
비공개 채널 권한 변경

### DIFF
--- a/apps/notice/tests.py
+++ b/apps/notice/tests.py
@@ -487,6 +487,17 @@ class PrivateChannelNoticeTest(TestCase):
         response = self.client.post(f"/api/v1/channels/{self.channel_id}/subscribe/")
 
         self.assertEqual(response.status_code, 204)
+        self.client.force_authenticate(user=self.manager)
+        response = self.client.post(
+            f"/api/v1/channels/{self.channel_id}/awaiters/allow/{self.subscriber.id}/"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.client.force_authenticate(user=self.subscriber)
+        response = self.client.get(f"/api/v1/channels/{self.channel_id}/notices/")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        print(data)
 
     def test_watcher_notice(self):
         self.client.force_authenticate(user=self.watcher)

--- a/apps/notice/views.py
+++ b/apps/notice/views.py
@@ -52,6 +52,7 @@ class NoticeIdViewSet(viewsets.GenericViewSet):
         if (
             channel.is_private
             and not channel.managers.filter(id=request.user.id).exists()
+            and not channel.subscribers.filter(id=request.user.id).exists()
         ):
             return Response(
                 {"error": "This channel is private."}, status=status.HTTP_403_FORBIDDEN
@@ -78,7 +79,11 @@ class NoticeIdViewSet(viewsets.GenericViewSet):
                 {"error": "Wrong Channel ID."}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        if channel.is_private and not (channel.managers.filter(id=request.user.id)):
+        if (
+            channel.is_private
+            and not channel.managers.filter(id=request.user.id).exists()
+            and not channel.subscribers.filter(id=request.user.id).exists()
+        ):
             return Response(
                 {"error": "This channel is private."}, status=status.HTTP_403_FORBIDDEN
             )


### PR DESCRIPTION
https://github.com/wafflestudio/SNUDAY-server/issues/62 의 오류를 해결했습니다.
위 이슈의 오류인 매니저가 일반 사용자로 변경되면 서버의 알림을 볼 수 없는 오류는 변경에서 생기는 오류가 아닌, 그냥 일반 구독자가 열람이 불가능하게 되어 있었던 것으로 보입니다.

일반 구독자가 비공개 채널의 알림을 열람 가능하도록 하고, 이를 검증하는 테스트를 추가했습니다.