### PR TITLE
구독자 없는 비공개 채널 생성 에러 해결

### DIFF
--- a/apps/channel/exceptions.py
+++ b/apps/channel/exceptions.py
@@ -1,0 +1,7 @@
+from rest_framework.exceptions import APIException
+
+
+class NoSubscriberInPrivateChannel(APIException):
+    status_code = 400
+    default_detail = "비공개 채널에 구독자가 한 명도 없어, 비공개 채널에 접근할 수 없습니다."
+    default_code = "no_subscriber_in_private_channel"

--- a/apps/channel/views.py
+++ b/apps/channel/views.py
@@ -1,7 +1,9 @@
 from django.db.models import Q
-from rest_framework import viewsets, status
+from django.db import transaction
+from rest_framework import viewsets, status, serializers
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from apps.channel.exceptions import NoSubscriberInPrivateChannel
 
 from apps.channel.models import Channel, Image
 from apps.channel.permission import ManagerCanModify
@@ -41,32 +43,47 @@ class ChannelViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        serializer = self.get_serializer(data=data)
-        serializer.is_valid(raise_exception=True)
-        serializer.save()
+        try:
+            with transaction.atomic():
+                serializer = self.get_serializer(data=data)
+                serializer.is_valid(raise_exception=True)
+                serializer.save()
 
-        p = re.compile('"([^",]*)"')
-        managers_list = p.findall(data["managers_id"])
-        managers_list.append(user.username)
+                p = re.compile('"([^",]*)"')
+                managers_list = p.findall(data["managers_id"])
+                managers_list.append(user.username)
 
-        channel = Channel.objects.get(id=serializer.data["id"])
+                channel = Channel.objects.get(id=serializer.data["id"])
 
-        if "image" in data:
-            image = Image.objects.create(image=data["image"])
-            image.channel = channel
-            image.save()
+                if "image" in data:
+                    image = Image.objects.create(image=data["image"])
+                    image.channel = channel
+                    image.save()
 
-        serializer = self.get_serializer(channel, data=data)
-        serializer.is_valid(raise_exception=True)
-        serializer.save()
+                serializer = self.get_serializer(channel, data=data)
+                serializer.is_valid(raise_exception=True)
+                serializer.save()
 
-        for manager in managers_list:
-            manager_obj = User.objects.get(username=manager)
-            channel.managers.add(manager_obj)
-            channel.subscribers.add(manager_obj)
+                for manager in managers_list:
+                    manager_obj = User.objects.get(username=manager)
+                    channel.managers.add(manager_obj)
+                    channel.subscribers.add(manager_obj)
 
-        serializer = self.get_serializer(channel, data=data)
-        serializer.is_valid(raise_exception=True)
+                serializer = self.get_serializer(channel, data=data)
+                serializer.is_valid(raise_exception=True)
+                serializer.save()
+
+                if (
+                    serializer.data.get["is_private"]
+                    and serializer.data["subscribers_count"] == 0
+                ):
+                    raise NoSubscriberInPrivateChannel
+
+        except NoSubscriberInPrivateChannel:
+            return Response(
+                {"error": "비공개 채널에 구독자가 한 명도 없어, 비공개 채널에 접근할 수 없습니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 


### PR DESCRIPTION
- 기존의 이미지 관련 에러로 인해 비공개 채널이 생성될 때 구독자 없이 생성되는 경우가 있었는데, 이러한 상황을 대비하여 최종적으로 비공개 채널에 구독자가 0명인 경우 채널 생성을 취소하는 로직을 추가하였습니다.
- 이미지 에러가 아닌 다른 원인으로도 같은 문제가 발생할 수 있을 것이라 생각하여 이후에도 다른 버그에 대비할 수 있을 것이라 생각합니다.
- 다만 한 가지 우려되는 점은, 이러한 형태의 오류를 `ValidationError`의 로직에 같이 넣기 어려워 별도의 `Custom Exception`을 추가하였는데, 오직 이 문제 하나 때문에 이렇 하는 것이 맞는지는 의견을 들어봐야 할 것 같습니다.