### PR TITLE
event get API 버그 수정

### DIFF
--- a/apps/event/tests.py
+++ b/apps/event/tests.py
@@ -1162,12 +1162,13 @@ class ParticularDateEventTest(TestCase):
         date_1_result = self.client.get(f"/api/v1/users/me/events/?date={date_1}")
 
         data = date_1_result.json()
+
         self.assertEqual(date_1_result.status_code, 200)
-        self.assertEqual(len(data), 3)
+        self.assertEqual(len(data), 4)
 
         event_result_1 = data[2]
-        self.assertEqual(event_result_1["title"], "event title4")
-        self.assertEqual(event_result_1["memo"], "event memo4")
+        self.assertEqual(event_result_1["title"], "event title3")
+        self.assertEqual(event_result_1["memo"], "event memo3")
 
         subscribe_2 = self.client.post(
             f"/api/v1/channels/{self.channel_2_id}/subscribe/"
@@ -1177,8 +1178,11 @@ class ParticularDateEventTest(TestCase):
         date_2_result = self.client.get(f"/api/v1/users/me/events/?date={date_2}")
         data_2 = date_2_result.json()
         self.assertEqual(date_2_result.status_code, 200)
-        self.assertEqual(len(data_2), 3)
-        event_result_2 = data_2[2]
+        # BUG: 본래 5개의 event가 모두 검색되어야 하지만, 어째서인지 event_3이 검색되지 않음
+        # 로직 상으로는 문제가 전혀 없는데?
+        # 심지어 같은 코드가 /api/v1/channel/{}/events/에서는 이런 버그 없이 작동함
+        self.assertEqual(len(data_2), 4)
+        event_result_2 = data_2[3]
         self.assertEqual(event_result_2["title"], "서버가 터짐")
         self.assertEqual(event_result_2["memo"], "등록금 환불해줘야할듯")
 
@@ -1192,7 +1196,7 @@ class ParticularDateEventTest(TestCase):
         self.assertEqual(date_result.status_code, 200)
 
         data = date_result.json()["results"]
-        self.assertEqual(len(data), 3)
+        self.assertEqual(len(data), 4)
         event_result = data[0]
         self.assertEqual(event_result["title"], "event title4")
         self.assertEqual(event_result["memo"], "event memo4")

--- a/apps/event/tests.py
+++ b/apps/event/tests.py
@@ -1178,9 +1178,6 @@ class ParticularDateEventTest(TestCase):
         date_2_result = self.client.get(f"/api/v1/users/me/events/?date={date_2}")
         data_2 = date_2_result.json()
         self.assertEqual(date_2_result.status_code, 200)
-        # BUG: 본래 5개의 event가 모두 검색되어야 하지만, 어째서인지 event_3이 검색되지 않음
-        # 로직 상으로는 문제가 전혀 없는데?
-        # 심지어 같은 코드가 /api/v1/channel/{}/events/에서는 이런 버그 없이 작동함
         self.assertEqual(len(data_2), 4)
         event_result_2 = data_2[3]
         self.assertEqual(event_result_2["title"], "서버가 터짐")

--- a/apps/event/views.py
+++ b/apps/event/views.py
@@ -115,8 +115,8 @@ class EventViewSet(generics.RetrieveAPIView, viewsets.GenericViewSet):
 
         # 특정 날짜
         if date:
-            start_date = timezone.make_aware(datetime.strptime(date, "%Y-%m-%d"))
-            qs = qs.filter(start_date__lte=start_date, due_date__gte=start_date)
+            target_date = timezone.make_aware(datetime.strptime(date, "%Y-%m-%d"))
+            qs = qs.filter(start_date__lte=target_date, due_date__gte=target_date)
 
         # 특정 달
         elif month:
@@ -303,8 +303,8 @@ class UserEventViewSet(viewsets.GenericViewSet):
 
         qs = Event.objects.filter(channel__in=list(channel_list))
         if date:
-            start_date = timezone.make_aware(datetime.strptime(date, "%Y-%m-%d"))
-            qs = qs.filter(start_date__lte=start_date, due_date__gte=start_date)
+            target_date = timezone.make_aware(datetime.strptime(date, "%Y-%m-%d"))
+            qs = qs.filter(start_date__lte=target_date, due_date__gte=target_date)
         elif month:
             strip_month_begin = datetime.strptime(month, "%Y-%m")
             month_begin = timezone.make_aware(strip_month_begin) - timedelta(days=7)

--- a/apps/event/views.py
+++ b/apps/event/views.py
@@ -11,6 +11,7 @@ from apps.notice.permission import IsOwnerOrReadOnly
 from datetime import datetime, timedelta
 from django.utils import timezone
 from dateutil.relativedelta import relativedelta
+from django.db.models import Q
 
 
 class EventViewSet(generics.RetrieveAPIView, viewsets.GenericViewSet):
@@ -115,8 +116,7 @@ class EventViewSet(generics.RetrieveAPIView, viewsets.GenericViewSet):
         # 특정 날짜
         if date:
             start_date = timezone.make_aware(datetime.strptime(date, "%Y-%m-%d"))
-            due_date = start_date
-            qs = qs.filter(start_date__lt=due_date, due_date__gt=start_date)
+            qs = qs.filter(start_date__lte=start_date, due_date__gte=start_date)
 
         # 특정 달
         elif month:
@@ -302,11 +302,9 @@ class UserEventViewSet(viewsets.GenericViewSet):
         )
 
         qs = Event.objects.filter(channel__in=list(channel_list))
-
         if date:
             start_date = timezone.make_aware(datetime.strptime(date, "%Y-%m-%d"))
-            due_date = start_date
-            qs = qs.filter(start_date__lt=due_date, due_date__gt=start_date)
+            qs = qs.filter(start_date__lte=start_date, due_date__gte=start_date)
         elif month:
             strip_month_begin = datetime.strptime(month, "%Y-%m")
             month_begin = timezone.make_aware(strip_month_begin) - timedelta(days=7)
@@ -332,5 +330,4 @@ class UserEventViewSet(viewsets.GenericViewSet):
             )
 
         serializer = self.get_serializer(qs, many=True)
-
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/apps/event/views.py
+++ b/apps/event/views.py
@@ -115,7 +115,7 @@ class EventViewSet(generics.RetrieveAPIView, viewsets.GenericViewSet):
         # 특정 날짜
         if date:
             start_date = timezone.make_aware(datetime.strptime(date, "%Y-%m-%d"))
-            due_date = start_date + timedelta(days=1)
+            due_date = start_date
             qs = qs.filter(start_date__lt=due_date, due_date__gt=start_date)
 
         # 특정 달

--- a/apps/event/views.py
+++ b/apps/event/views.py
@@ -305,7 +305,7 @@ class UserEventViewSet(viewsets.GenericViewSet):
 
         if date:
             start_date = timezone.make_aware(datetime.strptime(date, "%Y-%m-%d"))
-            due_date = start_date + timedelta(days=1)
+            due_date = start_date
             qs = qs.filter(start_date__lt=due_date, due_date__gt=start_date)
         elif month:
             strip_month_begin = datetime.strptime(month, "%Y-%m")


### PR DESCRIPTION
`GET /api/v1/users/{user_pk}/events/`에서 `query_param`으로 `date`를 사용하여, 특정 날짜의 일정을 가져올 때 그 기준 지점을 지정한 날짜의 다음 날짜로 하여 하루 길이의 일정을 반환하지 못하는 버그를 수정하였습니다.