### PR TITLE
refactor: interpret managers_id as username

### DIFF
--- a/apps/channel/serializers.py
+++ b/apps/channel/serializers.py
@@ -50,11 +50,13 @@ class ChannelSerializer(serializers.ModelSerializer):
         return subscribers_count
 
     def validate(self, data):
+
         if "managers_id" in data and data["managers_id"]:
+            try:
+                q = User.objects.get(username=data["managers_id"])
 
-            q = User.objects.filter(id=data["managers_id"])
-
-            if q.count() == 0:
+                data["managers_id"] = q.id
+            except User.DoesNotExist:
                 raise serializers.ValidationError("존재하지 않는 사용자를 관리자로 지정하였습니다.")
 
         return data

--- a/apps/channel/tests.py
+++ b/apps/channel/tests.py
@@ -19,7 +19,7 @@ class ChannelTest(TestCase):
             "name": "wafflestudio",
             "description": "맛있는 서비스가 탄생하는 곳, 서울대학교 컴퓨터공학부 웹/앱 개발 동아리 와플스튜디오입니다!",
             "is_private": False,
-            "managers_id": self.user.id,
+            "managers_id": self.user.username,
         }
         self.client = APIClient()
         self.client.force_authenticate(user=self.user)
@@ -27,7 +27,7 @@ class ChannelTest(TestCase):
     def test_create_channel(self):
         create = self.client.post("/api/v1/channels/", self.data, format="json")
         data = create.json()
-        channel = Channel.objects.get(id=data["id"])
+        channel = Channel.objects.get(managers=self.user)
         self.assertEqual(channel.managers.username, self.user.username)
         self.assertEqual(create.status_code, 201)
 
@@ -43,7 +43,6 @@ class ChannelTest(TestCase):
             "name": "wafflestudio",
             "description": "맛있는 서비스가 탄생하는 곳, 서울대학교 컴퓨터공학부 웹/앱 개발 동아리 와플스튜디오입니다!",
             "is_private": False,
-            "managers_id": self.user.id + 100,
         }
 
         create = self.client.post(
@@ -56,6 +55,7 @@ class ChannelTest(TestCase):
             "name": "wafflestudio",
             "description": "맛있는 서비스가 탄생하는 곳, 서울대학교 컴퓨터공학부 웹/앱 개발 동아리 와플스튜디오입니다!",
             "is_private": False,
+            "managers_id": "esioprise",
         }
 
         create = self.client.post(
@@ -155,7 +155,7 @@ class ChannelPermissionTest(TestCase):
 
         update = self.client.patch(
             f"/api/v1/channels/{self.public_channel.id}/",
-            {"description": content, "managers_id": self.b.id},
+            {"description": content, "managers_id": self.b.username},
             format="json",
         )
         self.assertEqual(update.status_code, 200)

--- a/apps/channel/views.py
+++ b/apps/channel/views.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from django.db.models import Q
 from django.db import transaction
 from rest_framework import viewsets, status, serializers
@@ -39,7 +40,7 @@ class ChannelViewSet(viewsets.ModelViewSet):
 
         if "managers_id" not in data:
             return Response(
-                {"error": "managers_id에 manager의 username 목록을 입력해야합니다."},
+                {"error": "managers_id에 manager의 username을 입력해야합니다."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -61,7 +62,9 @@ class ChannelViewSet(viewsets.ModelViewSet):
                 serializer.save()
 
                 manager_obj = User.objects.get(
-                    id=data["managers_id"] if data["managers_id"] else user.id
+                    username=data["managers_id"]
+                    if data["managers_id"]
+                    else user.username
                 )
                 channel.managers = manager_obj
                 channel.subscribers.add(manager_obj)
@@ -118,10 +121,11 @@ class ChannelViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(channel, data=data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
+
         if "managers_id" in data and data["managers_id"]:
             current_manager = channel.managers
             if current_manager.id != data["managers_id"]:
-                manager = User.objects.get(id=data["managers_id"])
+                manager = User.objects.get(username=data["managers_id"])
                 channel.managers = manager
                 channel.subscribers.add(manager)
 

--- a/apps/user/tests.py
+++ b/apps/user/tests.py
@@ -37,14 +37,14 @@ class UserCreateDeleteTest(TestCase):
             "name": "wafflestudio",
             "description": "맛있는 서비스가 탄생하는 곳, 서울대학교 컴퓨터공학부 웹/앱 개발 동아리 와플스튜디오입니다!",
             "is_private": False,
-            "managers_id": self.user.id,
+            "managers_id": self.user.username,
         }
 
         self.private_channel_data = {
             "name": "wafflestudio 18-5",
             "description": "맛있는 서비스가 탄생하는 곳, 서울대학교 컴퓨터공학부 웹/앱 개발 동아리 와플스튜디오입니다!",
             "is_private": True,
-            "managers_id": self.user.id,
+            "managers_id": self.user.username,
         }
 
         self.client = APIClient()


### PR DESCRIPTION
`POST /api/v1/channels/`, `​PATCH /api​/v1​/users​/{user_pk}​/` 등등 request body에 `managers_id`가 포함된 API를 처리할 때, `managers_id`에서 단일 string을 받으며, 그 string을 관리자의 username으로 해석하도록 코드를 변경하였습니다.