### PR TITLE
채널 삭제 API 추가

### DIFF
--- a/apps/channel/tests.py
+++ b/apps/channel/tests.py
@@ -137,6 +137,7 @@ class ChannelPermissionTest(TestCase):
         self.assertEqual(delete.status_code, 200)
 
         self.assertEqual(Channel.objects.count(), 1)
+        self.assertEqual(self.user.managing_channels.count(), 1)
 
     def test_delete_with_nonexistent_channel_will_fail(self):
         self.client.force_authenticate(user=self.user)

--- a/apps/channel/tests.py
+++ b/apps/channel/tests.py
@@ -134,7 +134,7 @@ class ChannelPermissionTest(TestCase):
         self.client.force_authenticate(user=self.user)
 
         delete = self.client.delete(f"/api/v1/channels/{self.public_channel.id}/")
-        self.assertEqual(delete.status_code, 200)
+        self.assertEqual(delete.status_code, 204)
 
         self.assertEqual(Channel.objects.count(), 1)
         self.assertEqual(self.user.managing_channels.count(), 1)
@@ -143,6 +143,9 @@ class ChannelPermissionTest(TestCase):
         self.client.force_authenticate(user=self.user)
 
         delete = self.client.delete(f"/api/v1/channels/-1/")
+        self.assertEqual(delete.status_code, 400)
+
+        delete = self.client.delete(f"/api/v1/channels/channel/")
         self.assertEqual(delete.status_code, 400)
 
     def test_update_without_permission_will_fail(self):
@@ -285,7 +288,7 @@ class ChannelPermissionTest(TestCase):
         disallow = self.client.delete(
             f"/api/v1/channels/{self.private_channel.id}/awaiters/allow/{self.b.id}/"
         )
-        self.assertEqual(disallow.status_code, 200)
+        self.assertEqual(disallow.status_code, 204)
         self.assertEqual(self.private_channel.awaiters.count(), 0)
         self.assertEqual(self.private_channel.subscribers.count(), 0)
 

--- a/apps/channel/tests.py
+++ b/apps/channel/tests.py
@@ -134,9 +134,15 @@ class ChannelPermissionTest(TestCase):
         self.client.force_authenticate(user=self.user)
 
         delete = self.client.delete(f"/api/v1/channels/{self.public_channel.id}/")
-        self.assertEqual(delete.status_code, 204)
+        self.assertEqual(delete.status_code, 200)
 
         self.assertEqual(Channel.objects.count(), 1)
+
+    def test_delete_with_nonexistent_channel_will_fail(self):
+        self.client.force_authenticate(user=self.user)
+
+        delete = self.client.delete(f"/api/v1/channels/-1/")
+        self.assertEqual(delete.status_code, 400)
 
     def test_update_without_permission_will_fail(self):
         self.client.force_authenticate(user=self.b)

--- a/apps/channel/views.py
+++ b/apps/channel/views.py
@@ -163,7 +163,7 @@ class ChannelViewSet(viewsets.ModelViewSet):
 
         self.check_object_permissions(self.request, channel)
         channel.delete()
-        return Response(status=status.HTTP_200_OK)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     def retrieve(self, request, pk=None):
         """
@@ -300,7 +300,7 @@ class ChannelViewSet(viewsets.ModelViewSet):
 
         else:
             channel.awaiters.remove(user)
-        return Response(status=status.HTTP_200_OK)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=False, methods=["get"])
     def recommend(self, request):

--- a/apps/channel/views.py
+++ b/apps/channel/views.py
@@ -155,7 +155,7 @@ class ChannelViewSet(viewsets.ModelViewSet):
                 {"error": "Wrong Channel ID."}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        if channel.manager != request.user:
+        if channel.managers != request.user:
             return Response(
                 {"error": "해당 채널의 매니저만 채널을 삭제할 수 있습니다."},
                 status=status.HTTP_403_FORBIDDEN,

--- a/apps/channel/views.py
+++ b/apps/channel/views.py
@@ -134,6 +134,37 @@ class ChannelViewSet(viewsets.ModelViewSet):
 
         return Response(serializer.data)
 
+    def destroy(self, request, pk=None):
+        """
+        # 채널 삭제 API
+        * {id}에는 channel의 id를 넣으면 됨
+        * 해당 채널의 매니저만 가능
+        * 존재하지 않는 채널이면 400
+        * 해당 채널의 매니저가 아니면 403
+        """
+        try:
+            channel_id = int(pk)
+            channel = Channel.objects.filter(id=channel_id).first()
+
+            if channel == None:
+                return Response(
+                    {"error": "Wrong Channel ID."}, status=status.HTTP_400_BAD_REQUEST
+                )
+        except ValueError:
+            return Response(
+                {"error": "Wrong Channel ID."}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        if channel.manager != request.user:
+            return Response(
+                {"error": "해당 채널의 매니저만 채널을 삭제할 수 있습니다."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        self.check_object_permissions(self.request, channel)
+        channel.delete()
+        return Response(status=status.HTTP_200_OK)
+
     def retrieve(self, request, pk=None):
         """
         # 채널 정보 GET API

--- a/apps/event/tests.py
+++ b/apps/event/tests.py
@@ -660,7 +660,7 @@ class PublicChannelEventTest(TestCase):
             )
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 204)
 
         self.assertIsNone(response.data)
 
@@ -961,7 +961,7 @@ class PrivateChannelEventTest(TestCase):
             )
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 204)
 
         self.assertIsNone(response.data)
 

--- a/apps/event/views.py
+++ b/apps/event/views.py
@@ -273,7 +273,7 @@ class EventViewSet(generics.RetrieveAPIView, viewsets.GenericViewSet):
         self.check_object_permissions(self.request, event)
         event.delete()
 
-        return Response(status=status.HTTP_200_OK)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class UserEventViewSet(viewsets.GenericViewSet):

--- a/apps/notice/tests.py
+++ b/apps/notice/tests.py
@@ -240,7 +240,7 @@ class PublicChannelNoticeTest(TestCase):
             )
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 204)
 
         self.assertIsNone(response.data)
 
@@ -475,7 +475,7 @@ class PrivateChannelNoticeTest(TestCase):
             )
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 204)
 
         self.assertIsNone(response.data)
 

--- a/apps/notice/views.py
+++ b/apps/notice/views.py
@@ -151,7 +151,7 @@ class NoticeIdViewSet(viewsets.GenericViewSet):
 
         self.check_object_permissions(self.request, notice)
         notice.delete()
-        return Response(status=status.HTTP_200_OK)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=False, methods=["get"])
     def search(self, request, channel_pk):


### PR DESCRIPTION
채널을 삭제하는 API `/api/v1/channels/{id}/`을 구현하고 swagger 설명을 추가하였으며, 관련 테스트 코드를 추가하였습니다. 기존에 swagger에 API 자체는 정의되어 있고 관련 테스트 코드의 뼈대도 마련되어 있어, 실제 API와 테스트 함수 내부 내용만 구현하였습니다.