### PR TITLE
비로그인 상태에서 public 채널 볼 수 있도록 함

### DIFF
--- a/apps/event/tests.py
+++ b/apps/event/tests.py
@@ -1120,9 +1120,7 @@ class PrivateChannelEventTest(TestCase):
         data = response.json()
         self.assertEqual(len(data), 0)
 
-    def test_watcher_event(self):
-        self.client.force_authenticate(user=self.watcher)
-
+    def test_unlogined_event(self):
         response = self.client.post(
             "/api/v1/channels/{}/events/".format(str(self.channel_id)),
             {
@@ -1135,7 +1133,7 @@ class PrivateChannelEventTest(TestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
 
         event_count = Event.objects.count()
         self.assertEqual(event_count, 1)
@@ -1148,7 +1146,7 @@ class PrivateChannelEventTest(TestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
 
         data = Event.objects.get(id=self.event_1.id)
 
@@ -1161,7 +1159,7 @@ class PrivateChannelEventTest(TestCase):
             )
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
 
         event_count = Event.objects.count()
         self.assertEqual(event_count, 1)
@@ -1183,10 +1181,7 @@ class PrivateChannelEventTest(TestCase):
 
         response = self.client.get("/api/v1/users/me/events/")
 
-        self.assertEqual(response.status_code, 200)
-
-        data = response.json()
-        self.assertEqual(len(data), 0)
+        self.assertEqual(response.status_code, 401)
 
     def test_subscriber_event(self):
         self.client.force_authenticate(user=self.watcher)

--- a/apps/event/tests.py
+++ b/apps/event/tests.py
@@ -825,6 +825,90 @@ class PublicChannelEventTest(TestCase):
         self.assertEqual(data["due_date"], "2021-03-03")
         self.assertFalse(data["has_time"])
 
+    def test_unlogined_event(self):
+
+        response = self.client.post(
+            "/api/v1/channels/{}/events/".format(str(self.channel_id)),
+            {
+                "title": "title",
+                "memo": "memo",
+                "start_date": "1998-12-11",
+                "due_date": "2021-03-03",
+                "has_time": False,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+        event_count = Event.objects.count()
+        self.assertEqual(event_count, 1)
+
+        response = self.client.patch(
+            "/api/v1/channels/{}/events/{}/".format(
+                str(self.channel_id), str(self.event_1.id)
+            ),
+            {"title": "updated title", "memo": "updated memo"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+        data = Event.objects.get(id=self.event_1.id)
+
+        self.assertEqual(data.title, "event title")
+        self.assertEqual(data.memo, "event memo")
+
+        response = self.client.delete(
+            "/api/v1/channels/{}/events/{}/".format(
+                str(self.channel_id), str(self.event_1.id)
+            )
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+        event_count = Event.objects.count()
+        self.assertEqual(event_count, 1)
+
+        response = self.client.get(
+            "/api/v1/channels/{}/events/{}/".format(
+                str(self.channel_id), str(self.event_1.id)
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertEqual(data["id"], self.event_1.id)
+        self.assertEqual(data["title"], "event title")
+        self.assertEqual(data["memo"], "event memo")
+        self.assertEqual(data["channel"], self.channel_id)
+        self.assertEqual(data["writer"], self.manager.id)
+        self.assertIn("created_at", data)
+        self.assertIn("updated_at", data)
+        self.assertEqual(data["start_date"], "1998-12-11")
+        self.assertEqual(data["due_date"], "2021-03-03")
+        self.assertFalse(data["has_time"])
+
+        response = self.client.get(
+            "/api/v1/channels/{}/events/?month=2021-03".format(str(self.channel_id))
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertEqual(len(data["results"]), 1)
+        data = data["results"][0]
+        self.assertEqual(data["id"], self.event_1.id)
+        self.assertEqual(data["title"], "event title")
+        self.assertEqual(data["memo"], "event memo")
+        self.assertEqual(data["channel"], self.channel_id)
+        self.assertEqual(data["writer"], self.manager.id)
+        self.assertIn("created_at", data)
+        self.assertIn("updated_at", data)
+        self.assertEqual(data["start_date"], "1998-12-11")
+        self.assertEqual(data["due_date"], "2021-03-03")
+        self.assertFalse(data["has_time"])
+
 
 class PrivateChannelEventTest(TestCase):
     def setUp(self):
@@ -967,6 +1051,74 @@ class PrivateChannelEventTest(TestCase):
 
         event_count = Event.objects.count()
         self.assertEqual(event_count, 1)
+
+    def test_watcher_event(self):
+        self.client.force_authenticate(user=self.watcher)
+
+        response = self.client.post(
+            "/api/v1/channels/{}/events/".format(str(self.channel_id)),
+            {
+                "title": "title",
+                "memo": "memo",
+                "start_date": "1998-12-11",
+                "due_date": "2021-03-03",
+                "has_time": False,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+        event_count = Event.objects.count()
+        self.assertEqual(event_count, 1)
+
+        response = self.client.patch(
+            "/api/v1/channels/{}/events/{}/".format(
+                str(self.channel_id), str(self.event_1.id)
+            ),
+            {"title": "updated title", "memo": "updated memo"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+        data = Event.objects.get(id=self.event_1.id)
+
+        self.assertEqual(data.title, "event title")
+        self.assertEqual(data.memo, "event memo")
+
+        response = self.client.delete(
+            "/api/v1/channels/{}/events/{}/".format(
+                str(self.channel_id), str(self.event_1.id)
+            )
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+        event_count = Event.objects.count()
+        self.assertEqual(event_count, 1)
+
+        response = self.client.get(
+            "/api/v1/channels/{}/events/{}/".format(
+                str(self.channel_id), str(self.event_1.id)
+            )
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.get(
+            "/api/v1/channels/{}/events/".format(str(self.channel_id))
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("error", response.json())
+
+        response = self.client.get("/api/v1/users/me/events/")
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertEqual(len(data), 0)
 
     def test_watcher_event(self):
         self.client.force_authenticate(user=self.watcher)

--- a/apps/notice/permission.py
+++ b/apps/notice/permission.py
@@ -4,6 +4,8 @@ from apps.channel.models import Channel
 
 class IsOwnerOrReadOnly(permissions.BasePermission):
     def has_permission(self, request, view):
+        if request.method == "GET":
+            return True
         return request.user.is_authenticated
 
     def has_object_permission(self, request, view, obj):

--- a/apps/notice/tests.py
+++ b/apps/notice/tests.py
@@ -362,7 +362,7 @@ class PublicChannelNoticeTest(TestCase):
         self.assertIn("created_at", data)
         self.assertIn("updated_at", data)
 
-    def test_watcher_notice(self):
+    def test_unlogined_notice(self):
 
         response = self.client.post(
             "/api/v1/channels/{}/notices/".format(str(self.channel_id)),

--- a/apps/notice/tests.py
+++ b/apps/notice/tests.py
@@ -362,6 +362,62 @@ class PublicChannelNoticeTest(TestCase):
         self.assertIn("created_at", data)
         self.assertIn("updated_at", data)
 
+    def test_watcher_notice(self):
+
+        response = self.client.post(
+            "/api/v1/channels/{}/notices/".format(str(self.channel_id)),
+            {"title": "title", "contents": "contents"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+        notice_count = Notice.objects.count()
+        self.assertEqual(notice_count, 1)
+
+        response = self.client.patch(
+            "/api/v1/channels/{}/notices/{}/".format(
+                str(self.channel_id), str(self.notice_1.id)
+            ),
+            {"title": "updated title", "contents": "updated contents"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+        data = Notice.objects.get(id=self.notice_1.id)
+
+        self.assertEqual(data.title, "notice title")
+        self.assertEqual(data.contents, "notice content")
+
+        response = self.client.delete(
+            "/api/v1/channels/{}/notices/{}/".format(
+                str(self.channel_id), str(self.notice_1.id)
+            )
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+        notice_count = Notice.objects.count()
+        self.assertEqual(notice_count, 1)
+
+        response = self.client.get(
+            "/api/v1/channels/{}/notices/{}/".format(
+                str(self.channel_id), str(self.notice_1.id)
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertEqual(data["id"], self.notice_1.id)
+        self.assertEqual(data["title"], "notice title")
+        self.assertEqual(data["contents"], "notice content")
+        self.assertEqual(data["channel"], self.channel_id)
+        self.assertEqual(data["writer"], self.manager.id)
+        self.assertIn("created_at", data)
+        self.assertIn("updated_at", data)
+
 
 class PrivateChannelNoticeTest(TestCase):
     def setUp(self):
@@ -847,10 +903,19 @@ class NoticeGetTest(TestCase):
             managers=self.manager,
         )
 
+        self.public_channel = Channel.objects.create(
+            name="wafflestudio2",
+            description="맛있는 서비스가 탄생하는 곳, 서울대학교 컴퓨터공학부 웹/앱 개발 동아리 와플스튜디오입니다!",
+            is_private=False,
+            managers=self.manager,
+        )
+
         self.channel_id = self.channel.id
         self.client = APIClient()
 
         self.notices = []
+
+        self.public_notices = []
 
         for i in range(1, 12):
             title = "notice" + str(i)
@@ -861,6 +926,16 @@ class NoticeGetTest(TestCase):
                 writer=self.manager,
             )
             self.notices.append(notice)
+
+        for i in range(1, 12):
+            title = "notice" + str(i)
+            notice = Notice.objects.create(
+                title=title,
+                contents="notice content",
+                channel=self.public_channel,
+                writer=self.manager,
+            )
+            self.public_notices.append(notice)
 
     def test_get_pagination(self):
         self.client.force_authenticate(user=self.manager)
@@ -941,7 +1016,7 @@ class NoticeGetTest(TestCase):
         self.assertIn("updated_at", data[0])
 
         response = self.client.get(
-            "/api/v1/channels/{}/recent_notices/".format(str(self.channel_id + 1)),
+            "/api/v1/channels/{}/recent_notices/".format(str(self.channel_id + 2)),
             format="json",
         )
 
@@ -954,3 +1029,116 @@ class NoticeGetTest(TestCase):
         )
 
         self.assertEqual(response.status_code, 403)
+
+    def test_get_public_unlogined(self):
+        response = self.client.get(
+            "/api/v1/channels/{}/notices/".format(str(self.channel_id)),
+            format="json",
+        )
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.get(
+            "/api/v1/channels/{}/notices/".format(str(self.public_channel.id)),
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        self.assertIn("next", data)
+        self.assertIsNone(data["previous"])
+        self.assertEqual(len(data["results"]), 10)
+
+        self.assertEqual(data["results"][0]["title"], "notice11")
+        self.assertEqual(data["results"][1]["title"], "notice10")
+        self.assertEqual(data["results"][9]["title"], "notice2")
+
+        response = self.client.get(
+            "/api/v1/users/me/notices/",
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_get_public_watcher(self):
+        self.client.force_authenticate(user=self.watcher)
+        response = self.client.get(
+            "/api/v1/channels/{}/notices/".format(str(self.channel_id)),
+            format="json",
+        )
+        self.assertEqual(response.status_code, 403)
+
+        response = self.client.get(
+            "/api/v1/channels/{}/notices/".format(str(self.public_channel.id)),
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        self.assertIn("next", data)
+        self.assertIsNone(data["previous"])
+        self.assertEqual(len(data["results"]), 10)
+
+        self.assertEqual(data["results"][0]["title"], "notice11")
+        self.assertEqual(data["results"][1]["title"], "notice10")
+        self.assertEqual(data["results"][9]["title"], "notice2")
+
+    def test_get_recent_notices_public_watcher(self):
+        self.client.force_authenticate(user=self.watcher)
+        response = self.client.get(
+            "/api/v1/channels/{}/recent_notices/".format(str(self.channel_id)),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        response = self.client.get(
+            "/api/v1/channels/{}/recent_notices/".format(str(self.public_channel.id)),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        self.assertEqual(len(data), 3)
+
+        self.assertEqual(data[0]["title"], "notice11")
+        self.assertEqual(data[1]["title"], "notice10")
+        self.assertEqual(data[2]["title"], "notice9")
+
+        self.assertIn("id", data[0])
+        self.assertEqual(data[0]["contents"], "notice content")
+        self.assertEqual(data[0]["channel"], self.public_channel.id)
+        self.assertEqual(data[0]["writer"], self.manager.id)
+        self.assertIn("created_at", data[0])
+        self.assertIn("updated_at", data[0])
+
+    def test_get_recent_notices_public_unlogined(self):
+        response = self.client.get(
+            "/api/v1/channels/{}/recent_notices/".format(str(self.channel_id)),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        response = self.client.get(
+            "/api/v1/channels/{}/recent_notices/".format(str(self.public_channel.id)),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        self.assertEqual(len(data), 3)
+
+        self.assertEqual(data[0]["title"], "notice11")
+        self.assertEqual(data[1]["title"], "notice10")
+        self.assertEqual(data[2]["title"], "notice9")
+
+        self.assertIn("id", data[0])
+        self.assertEqual(data[0]["contents"], "notice content")
+        self.assertEqual(data[0]["channel"], self.public_channel.id)
+        self.assertEqual(data[0]["writer"], self.manager.id)
+        self.assertIn("created_at", data[0])
+        self.assertIn("updated_at", data[0])

--- a/apps/notice/tests.py
+++ b/apps/notice/tests.py
@@ -720,8 +720,7 @@ class NoticeSearchTest(TestCase):
         self.assertEqual(title_search.status_code, 200)
 
     def test_search_channel_notice_contents(self):
-        self.client.force_authenticate(user=self.watcher)
-
+        # 비로그인 상태에서도 search 되는지 검사
         type = "contents"
         keyword = "귀여운"
         contents_search = self.client.get(

--- a/apps/notice/views.py
+++ b/apps/notice/views.py
@@ -191,7 +191,7 @@ class NoticeIdViewSet(viewsets.GenericViewSet):
 class NoticeRecentViewSet(viewsets.GenericViewSet):
     queryset = Notice.objects.all()
     serializer_class = NoticeChannelNameSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsOwnerOrReadOnly]
 
     @action(detail=True, methods=["GET"])
     def recent_notices(self, request, pk=None):


### PR DESCRIPTION
- `channels/{channel_pk}/events/`
- `channels/{channel_pk}/events/{id}/`
- `channels/{channel_pk}/notices/`
- `channels/{channel_pk}/notices/search/`
- `channels/{channel_pk}/notices/{id}/`
- `channels/{channel_pk}/recent_notices/`
에서 public 채널을 볼 수 있도록 비로그인 상태에서도 get은 401이 뜨지 않도록 바꿨습니다.
이를 테스트하는 테스트들을 추가했습니다.