### PR TITLE
이메일 백엔드 변경

### DIFF
--- a/settings/base.py
+++ b/settings/base.py
@@ -154,7 +154,7 @@ DEFAULT_FILE_STORAGE = "apps.core.storage.MediaStorage"
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_USE_TLS = True
-EMAIL_HOST = "smtp.gmail.com"
+EMAIL_HOST = "smtp.sendgrind.net"
 EMAIL_PORT = 587
 EMAIL_HOST_USER = "waffle.snuday@gmail.com"  # ex) bum752@gmail.com
 EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_PASSWORD")  # ex) P@ssw0rd

--- a/settings/base.py
+++ b/settings/base.py
@@ -154,11 +154,11 @@ DEFAULT_FILE_STORAGE = "apps.core.storage.MediaStorage"
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_USE_TLS = True
-EMAIL_HOST = "smtp.sendgrind.net"
+EMAIL_HOST = "smtp.sendgrid.net"
 EMAIL_PORT = 587
-EMAIL_HOST_USER = "waffle.snuday@gmail.com"  # ex) bum752@gmail.com
+EMAIL_HOST_USER = "apikey"  # ex) bum752@gmail.com
 EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_PASSWORD")  # ex) P@ssw0rd
-SERVER_EMAIL = "waffle.snuday"  # ex) bum752@gmail.com
-DEFAULT_FROM_MAIL = "snuday"  # ex) bum752
+DEFAULT_FROM_EMAIL = "waffle.snuday@gmail.com"  # ex) bum752@gmail.com
+# DEFAULT_FROM_MAIL = "snuday"  # ex) bum752
 # Date input format
 DATE_INPUT_FORMATS = ("%Y-%m-%d",)


### PR DESCRIPTION
 - 이메일 백엔드를 `sendgrid`라는 서비스로 변경해서, 구글 인증 이슈를 해결했습니다.