### PR TITLE
Color fix

### DIFF
--- a/apps/channel/serializers.py
+++ b/apps/channel/serializers.py
@@ -123,17 +123,17 @@ class ChannelAwaiterSerializer(serializers.ModelSerializer):
 
     def get_color(self, channel):
         if "request" not in self.context:
-            return None
+            return random_color()
         request = self.context["request"]
         if request is None:
-            return None
+            return random_color()
         try:
             color_data = UserChannelColorSerializer(
                 UserChannel.objects.get(channel=channel, user=request.user),
                 context={"request": request},
             )
         except UserChannel.DoesNotExist:
-            return None
+            return random_color()
         return color_data.data["color"]
 
     def get_subscribers_count(self, channel):

--- a/apps/channel/tests.py
+++ b/apps/channel/tests.py
@@ -465,7 +465,7 @@ class ChannelColorTest(TestCase):
         subscribe = self.client.post(f"/api/v1/channels/{self.channel1.id}/subscribe/")
 
         self.client.force_authenticate(user=self.user2)
-        color_data = self.client.get(f"/api/v1/channels/{self.channel1.id}/color/")
+        color_data = self.client.get(f"/api/v1/channels/{self.channel1.id}/")
 
         data = color_data.json()
         self.assertIn("color", data)
@@ -501,6 +501,10 @@ class ChannelColorTest(TestCase):
         )
 
         self.assertEqual(color_update.status_code, 400)
+
+        color_data = self.client.get(f"/api/v1/channels/{self.channel1.id}/")
+        data = color_data.json()
+        self.assertEqual(data["color"], None)
 
     def test_patch_wrong_channel_color_will_fail(self):
         self.client.force_authenticate(user=self.user)


### PR DESCRIPTION
- 기존에 `Channel` 정보를 불러올 때 `user`와 `channel`의 관계에 종속된 `color` 정보는 나타나지 않았는데, 이제 색 정보가 `color` 필드에 포함되어 응답을 하도록 하였습니다.
- 로그인을 하지 않은 유저거나, 구독자가 아닌 등 `color` 정보가 없는 경우 랜덤한 색을 반환합니다.