### PR TITLE
chore: seperate dev and production settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,8 @@ services:
     env_file:
       - ./.env
     working_dir: /root
-    command: python manage.py runserver 0.0.0.0:8000
+    command: python manage.py runserver 0.0.0.0:8000 --settings=mysite.config.settings.dev
+    # command: python manage.py runserver 0.0.0.0:8000 --settings=mysite.config.settings.prod
     depends_on:
       mysql:
         condition: service_healthy

--- a/settings/dev.py
+++ b/settings/dev.py
@@ -1,3 +1,15 @@
 from settings.base import *
 
 DEBUG = True
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.mysql",
+        "HOST": os.environ.get("DB_HOST", "localhost"),
+        "PORT": os.environ.get("DB_PORT"),
+        "NAME": os.environ.get("DB_NAME") + "_dev",
+        "USER": os.environ.get("DB_USERNAME"),
+        "PASSWORD": os.environ.get("DB_PASSWORD"),
+        "OPTIONS": {"charset": "utf8mb4"},
+    },
+}

--- a/settings/prod.py
+++ b/settings/prod.py
@@ -1,3 +1,17 @@
 from settings.base import *
 
 DEBUG = False
+
+ALLOWED_HOSTS = ["*"]
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.mysql",
+        "HOST": os.environ.get("DB_HOST", "localhost"),
+        "PORT": os.environ.get("DB_PORT"),
+        "NAME": os.environ.get("DB_NAME") + "_prod",
+        "USER": os.environ.get("DB_USERNAME"),
+        "PASSWORD": os.environ.get("DB_PASSWORD"),
+        "OPTIONS": {"charset": "utf8mb4"},
+    },
+}


### PR DESCRIPTION
- debugging용 DB와 서비스용 DB를 분리했습니다. 각 DB 이름은 `snuday_dev`와 `snuday_prod`입니다.
- debugging할 때와 서비스 할 때 사용하는 DB를 달리하기 위해 settings 파일을 분리하여 `dev.py`와 `prod.py`에 각 DB 설정을 기록하였습니다.
- `docker-compose.yml`의 실행 커맨드를 변경하였습니다. 현재는 debugging용 설정(`dev.py` 설정)이 지정되었습니다. 주석 위치를 바꿔서 실제 서비스용 DB로 전환할 수 있습니다. (정상 작동하는지는 배포 시 다시 확인해 봐야 함)